### PR TITLE
LPS-70745 Auto

### DIFF
--- a/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMStructureLocalService.java
+++ b/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMStructureLocalService.java
@@ -590,6 +590,10 @@ public interface DDMStructureLocalService extends BaseLocalService,
 		java.lang.String name, java.lang.String description,
 		java.lang.String storageType, int type, int status, boolean andOperator);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(long companyId, long[] groupIds, long classNameId,
+		long classPK, java.lang.String keywords) throws PortalException;
+
 	/**
 	* Returns the OSGi service identifier.
 	*
@@ -996,6 +1000,12 @@ public interface DDMStructureLocalService extends BaseLocalService,
 		java.lang.String storageType, int type, int status,
 		boolean andOperator, int start, int end,
 		OrderByComparator<DDMStructure> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMStructure> search(long companyId, long[] groupIds,
+		long classNameId, long classPK, java.lang.String keywords, int start,
+		int end, OrderByComparator<DDMStructure> orderByComparator)
+		throws PortalException;
 
 	/**
 	* Returns the number of rows matching the dynamic query.

--- a/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMStructureLocalServiceUtil.java
+++ b/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMStructureLocalServiceUtil.java
@@ -706,6 +706,14 @@ public class DDMStructureLocalServiceUtil {
 			description, storageType, type, status, andOperator);
 	}
 
+	public static int searchCount(long companyId, long[] groupIds,
+		long classNameId, long classPK, java.lang.String keywords)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .searchCount(companyId, groupIds, classNameId, classPK,
+			keywords);
+	}
+
 	/**
 	* Returns the OSGi service identifier.
 	*
@@ -1175,6 +1183,16 @@ public class DDMStructureLocalServiceUtil {
 				   .search(companyId, groupIds, classNameId, name, description,
 			storageType, type, status, andOperator, start, end,
 			orderByComparator);
+	}
+
+	public static java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> search(
+		long companyId, long[] groupIds, long classNameId, long classPK,
+		java.lang.String keywords, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> orderByComparator)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .search(companyId, groupIds, classNameId, classPK, keywords,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMStructureLocalServiceWrapper.java
+++ b/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMStructureLocalServiceWrapper.java
@@ -738,6 +738,14 @@ public class DDMStructureLocalServiceWrapper implements DDMStructureLocalService
 			andOperator);
 	}
 
+	@Override
+	public int searchCount(long companyId, long[] groupIds, long classNameId,
+		long classPK, java.lang.String keywords)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _ddmStructureLocalService.searchCount(companyId, groupIds,
+			classNameId, classPK, keywords);
+	}
+
 	/**
 	* Returns the OSGi service identifier.
 	*
@@ -1232,6 +1240,16 @@ public class DDMStructureLocalServiceWrapper implements DDMStructureLocalService
 		return _ddmStructureLocalService.search(companyId, groupIds,
 			classNameId, name, description, storageType, type, status,
 			andOperator, start, end, orderByComparator);
+	}
+
+	@Override
+	public java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> search(
+		long companyId, long[] groupIds, long classNameId, long classPK,
+		java.lang.String keywords, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> orderByComparator)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _ddmStructureLocalService.search(companyId, groupIds,
+			classNameId, classPK, keywords, start, end, orderByComparator);
 	}
 
 	/**

--- a/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureFinder.java
+++ b/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureFinder.java
@@ -23,6 +23,9 @@ import aQute.bnd.annotation.ProviderType;
 @ProviderType
 public interface DDMStructureFinder {
 	public int countByKeywords(long companyId, long[] groupIds,
+		long classNameId, long classPK, java.lang.String keywords);
+
+	public int countByKeywords(long companyId, long[] groupIds,
 		long classNameId, java.lang.String keywords, int status);
 
 	public int countByC_G_C_S(long companyId, long[] groupIds,
@@ -74,6 +77,11 @@ public interface DDMStructureFinder {
 		java.lang.String[] names, java.lang.String[] descriptions,
 		java.lang.String storageType, int type, int status,
 		boolean andOperator, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> orderByComparator);
+
+	public java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> findByKeywords(
+		long companyId, long[] groupIds, long classNameId, long classPK,
+		java.lang.String keywords, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> orderByComparator);
 
 	public java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> findByKeywords(

--- a/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/comparator/StructureCreateDateComparator.java
+++ b/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/comparator/StructureCreateDateComparator.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.util.comparator;
+
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class StructureCreateDateComparator
+	extends OrderByComparator<DDMStructure> {
+
+	public static final String ORDER_BY_ASC = "DDMStructure.createDate ASC";
+
+	public static final String ORDER_BY_DESC = "DDMStructure.createDate DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"createDate"};
+
+	public StructureCreateDateComparator() {
+		this(false);
+	}
+
+	public StructureCreateDateComparator(boolean ascending) {
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(DDMStructure structure1, DDMStructure structure2) {
+		int value = DateUtil.compareTo(
+			structure1.getCreateDate(), structure2.getCreateDate());
+
+		if (_ascending) {
+			return value;
+		}
+		else {
+			return -value;
+		}
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+		else {
+			return ORDER_BY_DESC;
+		}
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private final boolean _ascending;
+
+}

--- a/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/comparator/StructureNameComparator.java
+++ b/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/comparator/StructureNameComparator.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.util.comparator;
+
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class StructureNameComparator extends OrderByComparator<DDMStructure> {
+
+	public static final String ORDER_BY_ASC = "DDMStructure.name ASC";
+
+	public static final String ORDER_BY_DESC = "DDMStructure.name DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"name"};
+
+	public StructureNameComparator() {
+		this(false);
+	}
+
+	public StructureNameComparator(boolean ascending) {
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(DDMStructure ddmStructure1, DDMStructure ddmStructure2) {
+		String name1 = StringUtil.toLowerCase(ddmStructure1.getName());
+		String name2 = StringUtil.toLowerCase(ddmStructure2.getName());
+
+		int value = name1.compareTo(name2);
+
+		if (_ascending) {
+			return value;
+		}
+		else {
+			return -value;
+		}
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+		else {
+			return ORDER_BY_DESC;
+		}
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private final boolean _ascending;
+
+}

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -1179,6 +1179,18 @@ public class DDMStructureLocalServiceImpl
 			structureVersion.getDDMFormLayout(), serviceContext);
 	}
 
+	@Override
+	public List<DDMStructure> search(
+			long companyId, long[] groupIds, long classNameId, long classPK,
+			String keywords, int start, int end,
+			OrderByComparator<DDMStructure> orderByComparator)
+		throws PortalException {
+
+		return ddmStructureFinder.findByKeywords(
+			companyId, groupIds, classNameId, classPK, keywords, start, end,
+			orderByComparator);
+	}
+
 	/**
 	 * Returns an ordered range of all the structures matching the groups and
 	 * class name IDs, and matching the keywords in the structure names and
@@ -1259,6 +1271,16 @@ public class DDMStructureLocalServiceImpl
 		return ddmStructureFinder.findByC_G_C_N_D_S_T_S(
 			companyId, groupIds, classNameId, name, description, storageType,
 			type, status, andOperator, start, end, orderByComparator);
+	}
+
+	@Override
+	public int searchCount(
+			long companyId, long[] groupIds, long classNameId, long classPK,
+			String keywords)
+		throws PortalException {
+
+		return ddmStructureFinder.countByKeywords(
+			companyId, groupIds, classNameId, classPK, keywords);
 	}
 
 	/**

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMContentPersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMContentPersistenceImpl.java
@@ -2766,8 +2766,41 @@ public class DDMContentPersistenceImpl extends BasePersistenceImpl<DDMContent>
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMContentModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMContentModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] { ddmContentModelImpl.getUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					ddmContentModelImpl.getUuid(),
+					ddmContentModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { ddmContentModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_GROUPID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_GROUPID,
+				args);
+
+			args = new Object[] { ddmContentModelImpl.getCompanyId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_COMPANYID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_COMPANYID,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMDataProviderInstanceLinkPersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMDataProviderInstanceLinkPersistenceImpl.java
@@ -1645,9 +1645,31 @@ public class DDMDataProviderInstanceLinkPersistenceImpl
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew ||
-				!DDMDataProviderInstanceLinkModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMDataProviderInstanceLinkModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					ddmDataProviderInstanceLinkModelImpl.getDataProviderInstanceId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_DATAPROVIDERINSTANCEID,
+				args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_DATAPROVIDERINSTANCEID,
+				args);
+
+			args = new Object[] {
+					ddmDataProviderInstanceLinkModelImpl.getStructureId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_STRUCTUREID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_STRUCTUREID,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMDataProviderInstancePersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMDataProviderInstancePersistenceImpl.java
@@ -3666,8 +3666,43 @@ public class DDMDataProviderInstancePersistenceImpl extends BasePersistenceImpl<
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMDataProviderInstanceModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMDataProviderInstanceModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					ddmDataProviderInstanceModelImpl.getUuid()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					ddmDataProviderInstanceModelImpl.getUuid(),
+					ddmDataProviderInstanceModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { ddmDataProviderInstanceModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_GROUPID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_GROUPID,
+				args);
+
+			args = new Object[] { ddmDataProviderInstanceModelImpl.getCompanyId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_COMPANYID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_COMPANYID,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStorageLinkPersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStorageLinkPersistenceImpl.java
@@ -2199,8 +2199,35 @@ public class DDMStorageLinkPersistenceImpl extends BasePersistenceImpl<DDMStorag
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMStorageLinkModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMStorageLinkModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] { ddmStorageLinkModelImpl.getUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					ddmStorageLinkModelImpl.getUuid(),
+					ddmStorageLinkModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { ddmStorageLinkModelImpl.getStructureId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_STRUCTUREID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_STRUCTUREID,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructureFinderImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructureFinderImpl.java
@@ -46,11 +46,39 @@ import java.util.List;
 public class DDMStructureFinderImpl
 	extends DDMStructureFinderBaseImpl implements DDMStructureFinder {
 
+	public static final String COUNT_BY_C_G_C_C_N_D =
+		DDMStructureFinder.class.getName() + ".countByC_G_C_C_N_D";
+
 	public static final String COUNT_BY_C_G_C_N_D_S_T_S =
 		DDMStructureFinder.class.getName() + ".countByC_G_C_N_D_S_T_S";
 
+	public static final String FIND_BY_C_G_C_C_N_D =
+		DDMStructureFinder.class.getName() + ".findByC_G_C_C_N_D";
+
 	public static final String FIND_BY_C_G_C_N_D_S_T_R =
 		DDMStructureFinder.class.getName() + ".findByC_G_C_N_D_S_T_S";
+
+	@Override
+	public int countByKeywords(
+		long companyId, long[] groupIds, long classNameId, long classPK,
+		String keywords) {
+
+		String[] names = null;
+		String[] descriptions = null;
+		boolean andOperator = false;
+
+		if (Validator.isNotNull(keywords)) {
+			names = CustomSQLUtil.keywords(keywords);
+			descriptions = CustomSQLUtil.keywords(keywords, false);
+		}
+		else {
+			andOperator = true;
+		}
+
+		return doCountByC_G_C_C_N_D(
+			companyId, groupIds, classNameId, classPK, names, descriptions,
+			andOperator);
+	}
 
 	@Override
 	public int countByKeywords(
@@ -237,6 +265,29 @@ public class DDMStructureFinderImpl
 
 	@Override
 	public List<DDMStructure> findByKeywords(
+		long companyId, long[] groupIds, long classNameId, long classPK,
+		String keywords, int start, int end,
+		OrderByComparator<DDMStructure> orderByComparator) {
+
+		String[] names = null;
+		String[] descriptions = null;
+		boolean andOperator = false;
+
+		if (Validator.isNotNull(keywords)) {
+			names = CustomSQLUtil.keywords(keywords);
+			descriptions = CustomSQLUtil.keywords(keywords, false);
+		}
+		else {
+			andOperator = true;
+		}
+
+		return doFindByC_G_C_C_N_D(
+			companyId, groupIds, classNameId, classPK, names, descriptions,
+			andOperator, start, end, orderByComparator);
+	}
+
+	@Override
+	public List<DDMStructure> findByKeywords(
 		long companyId, long[] groupIds, long classNameId, String keywords,
 		int status, int start, int end,
 		OrderByComparator<DDMStructure> orderByComparator) {
@@ -298,6 +349,69 @@ public class DDMStructureFinderImpl
 		return doFindByC_G_C_N_D_S_T_S(
 			companyId, groupIds, classNameId, names, descriptions, storageType,
 			type, status, andOperator, start, end, orderByComparator, false);
+	}
+
+	protected int doCountByC_G_C_C_N_D(
+		long companyId, long[] groupIds, long classNameId, long classPK,
+		String[] names, String[] descriptions, boolean andOperator) {
+
+		names = CustomSQLUtil.keywords(names);
+		descriptions = CustomSQLUtil.keywords(descriptions, false);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = CustomSQLUtil.get(getClass(), COUNT_BY_C_G_C_C_N_D);
+
+			sql = StringUtil.replace(
+				sql, "[$GROUP_ID$]", getGroupIds(groupIds));
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "lower(CAST_TEXT(DDMStructure.name))", StringPool.LIKE,
+				false, names);
+
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "DDMStructure.description", StringPool.LIKE, true,
+				descriptions);
+
+			sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addScalar(COUNT_COLUMN_NAME, Type.LONG);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(companyId);
+
+			if (groupIds != null) {
+				qPos.add(groupIds);
+			}
+
+			qPos.add(classNameId);
+			qPos.add(classPK);
+			qPos.add(names, 2);
+			qPos.add(descriptions, 2);
+
+			Iterator<Long> itr = q.iterate();
+
+			if (itr.hasNext()) {
+				Long count = itr.next();
+
+				if (count != null) {
+					return count.intValue();
+				}
+			}
+
+			return 0;
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
 	}
 
 	protected int doCountByC_G_C_N_D_S_T_S(
@@ -371,6 +485,63 @@ public class DDMStructureFinderImpl
 			}
 
 			return 0;
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected List<DDMStructure> doFindByC_G_C_C_N_D(
+		long companyId, long[] groupIds, long classNameId, long classPK,
+		String[] names, String[] descriptions, boolean andOperator, int start,
+		int end, OrderByComparator<DDMStructure> orderByComparator) {
+
+		names = CustomSQLUtil.keywords(names);
+		descriptions = CustomSQLUtil.keywords(descriptions, false);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = CustomSQLUtil.get(getClass(), FIND_BY_C_G_C_C_N_D);
+
+			sql = StringUtil.replace(
+				sql, "[$GROUP_ID$]", getGroupIds(groupIds));
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "lower(CAST_TEXT(DDMStructure.name))", StringPool.LIKE,
+				false, names);
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "DDMStructure.description", StringPool.LIKE, true,
+				descriptions);
+			sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
+
+			if (orderByComparator != null) {
+				sql = CustomSQLUtil.replaceOrderBy(sql, orderByComparator);
+			}
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addEntity("DDMStructure", DDMStructureImpl.class);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(companyId);
+
+			if (groupIds != null) {
+				qPos.add(groupIds);
+			}
+
+			qPos.add(classNameId);
+			qPos.add(classPK);
+			qPos.add(names, 2);
+			qPos.add(descriptions, 2);
+
+			return (List<DDMStructure>)QueryUtil.list(
+				q, getDialect(), start, end);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructureLayoutPersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructureLayoutPersistenceImpl.java
@@ -2025,8 +2025,29 @@ public class DDMStructureLayoutPersistenceImpl extends BasePersistenceImpl<DDMSt
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMStructureLayoutModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMStructureLayoutModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] { ddmStructureLayoutModelImpl.getUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					ddmStructureLayoutModelImpl.getUuid(),
+					ddmStructureLayoutModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructureLinkPersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructureLinkPersistenceImpl.java
@@ -2175,8 +2175,37 @@ public class DDMStructureLinkPersistenceImpl extends BasePersistenceImpl<DDMStru
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMStructureLinkModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMStructureLinkModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					ddmStructureLinkModelImpl.getClassNameId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_CLASSNAMEID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_CLASSNAMEID,
+				args);
+
+			args = new Object[] { ddmStructureLinkModelImpl.getStructureId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_STRUCTUREID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_STRUCTUREID,
+				args);
+
+			args = new Object[] {
+					ddmStructureLinkModelImpl.getClassNameId(),
+					ddmStructureLinkModelImpl.getClassPK()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_C_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_C,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructurePersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructurePersistenceImpl.java
@@ -10948,8 +10948,102 @@ public class DDMStructurePersistenceImpl extends BasePersistenceImpl<DDMStructur
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMStructureModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMStructureModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] { ddmStructureModelImpl.getUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					ddmStructureModelImpl.getUuid(),
+					ddmStructureModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { ddmStructureModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_GROUPID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_GROUPID,
+				args);
+
+			args = new Object[] { ddmStructureModelImpl.getParentStructureId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_PARENTSTRUCTUREID,
+				args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_PARENTSTRUCTUREID,
+				args);
+
+			args = new Object[] { ddmStructureModelImpl.getClassNameId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_CLASSNAMEID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_CLASSNAMEID,
+				args);
+
+			args = new Object[] { ddmStructureModelImpl.getStructureKey() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_STRUCTUREKEY, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_STRUCTUREKEY,
+				args);
+
+			args = new Object[] {
+					ddmStructureModelImpl.getGroupId(),
+					ddmStructureModelImpl.getParentStructureId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_P, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_P,
+				args);
+
+			args = new Object[] {
+					ddmStructureModelImpl.getGroupId(),
+					ddmStructureModelImpl.getClassNameId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C,
+				args);
+
+			args = new Object[] {
+					ddmStructureModelImpl.getCompanyId(),
+					ddmStructureModelImpl.getClassNameId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_C_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_C,
+				args);
+
+			args = new Object[] {
+					ddmStructureModelImpl.getGroupId(),
+					ddmStructureModelImpl.getName(),
+					ddmStructureModelImpl.getDescription()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_N_D, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_N_D,
+				args);
+
+			args = new Object[] {
+					ddmStructureModelImpl.getGroupId(),
+					ddmStructureModelImpl.getClassNameId(),
+					ddmStructureModelImpl.getName(),
+					ddmStructureModelImpl.getDescription()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C_N_D, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C_N_D,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructureVersionPersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMStructureVersionPersistenceImpl.java
@@ -1673,8 +1673,31 @@ public class DDMStructureVersionPersistenceImpl extends BasePersistenceImpl<DDMS
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMStructureVersionModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMStructureVersionModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					ddmStructureVersionModelImpl.getStructureId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_STRUCTUREID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_STRUCTUREID,
+				args);
+
+			args = new Object[] {
+					ddmStructureVersionModelImpl.getStructureId(),
+					ddmStructureVersionModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_S_S, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_S_S,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMTemplateLinkPersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMTemplateLinkPersistenceImpl.java
@@ -1589,8 +1589,28 @@ public class DDMTemplateLinkPersistenceImpl extends BasePersistenceImpl<DDMTempl
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMTemplateLinkModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMTemplateLinkModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					ddmTemplateLinkModelImpl.getClassNameId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_CLASSNAMEID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_CLASSNAMEID,
+				args);
+
+			args = new Object[] { ddmTemplateLinkModelImpl.getTemplateId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_TEMPLATEID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_TEMPLATEID,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMTemplatePersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMTemplatePersistenceImpl.java
@@ -12230,8 +12230,120 @@ public class DDMTemplatePersistenceImpl extends BasePersistenceImpl<DDMTemplate>
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMTemplateModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMTemplateModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] { ddmTemplateModelImpl.getUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					ddmTemplateModelImpl.getUuid(),
+					ddmTemplateModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { ddmTemplateModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_GROUPID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_GROUPID,
+				args);
+
+			args = new Object[] { ddmTemplateModelImpl.getClassPK() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_CLASSPK, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_CLASSPK,
+				args);
+
+			args = new Object[] { ddmTemplateModelImpl.getTemplateKey() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_TEMPLATEKEY, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_TEMPLATEKEY,
+				args);
+
+			args = new Object[] { ddmTemplateModelImpl.getType() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_TYPE, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_TYPE,
+				args);
+
+			args = new Object[] { ddmTemplateModelImpl.getLanguage() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_LANGUAGE, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_LANGUAGE,
+				args);
+
+			args = new Object[] {
+					ddmTemplateModelImpl.getGroupId(),
+					ddmTemplateModelImpl.getClassNameId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C,
+				args);
+
+			args = new Object[] {
+					ddmTemplateModelImpl.getGroupId(),
+					ddmTemplateModelImpl.getClassPK()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_CPK, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_CPK,
+				args);
+
+			args = new Object[] {
+					ddmTemplateModelImpl.getGroupId(),
+					ddmTemplateModelImpl.getClassNameId(),
+					ddmTemplateModelImpl.getClassPK()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C_C,
+				args);
+
+			args = new Object[] {
+					ddmTemplateModelImpl.getClassNameId(),
+					ddmTemplateModelImpl.getClassPK(),
+					ddmTemplateModelImpl.getType()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_C_C_T, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_C_T,
+				args);
+
+			args = new Object[] {
+					ddmTemplateModelImpl.getGroupId(),
+					ddmTemplateModelImpl.getClassNameId(),
+					ddmTemplateModelImpl.getClassPK(),
+					ddmTemplateModelImpl.getType()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C_C_T, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C_C_T,
+				args);
+
+			args = new Object[] {
+					ddmTemplateModelImpl.getGroupId(),
+					ddmTemplateModelImpl.getClassNameId(),
+					ddmTemplateModelImpl.getClassPK(),
+					ddmTemplateModelImpl.getType(),
+					ddmTemplateModelImpl.getMode()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C_C_T_M, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C_C_T_M,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMTemplateVersionPersistenceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMTemplateVersionPersistenceImpl.java
@@ -1666,8 +1666,31 @@ public class DDMTemplateVersionPersistenceImpl extends BasePersistenceImpl<DDMTe
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !DDMTemplateVersionModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!DDMTemplateVersionModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					ddmTemplateVersionModelImpl.getTemplateId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_TEMPLATEID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_TEMPLATEID,
+				args);
+
+			args = new Object[] {
+					ddmTemplateVersionModelImpl.getTemplateId(),
+					ddmTemplateVersionModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_T_S, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_T_S,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/dynamic-data-mapping-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/dynamic-data-mapping-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -41,6 +41,26 @@
 				DDMDataProviderInstance.dataProviderInstanceId DESC
 		]]>
 	</sql>
+	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMStructureFinder.countByC_G_C_C_N_D">
+		<![CDATA[
+			SELECT
+				COUNT(DDMStructure.structureId) AS COUNT_VALUE
+			FROM
+				DDMStructure
+			INNER JOIN
+				DDMStructureLink ON
+					(DDMStructure.structureId = DDMStructureLink.structureId)
+			WHERE
+				(DDMStructure.companyId = ?) AND
+				[$GROUP_ID$]
+				(DDMStructureLink.classNameId = ?) AND
+				(DDMStructureLink.classPK = ?) AND
+				(
+					(lower(CAST_TEXT(DDMStructure.name)) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(DDMStructure.description LIKE ? [$AND_OR_NULL_CHECK$])
+				)
+		]]>
+	</sql>
 	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMStructureFinder.countByC_G_C_N_D_S_T_S">
 		<![CDATA[
 			SELECT
@@ -58,6 +78,28 @@
 				(storageType = ? OR ? IS NULL) AND
 				(type_ = ?)
 				[$STATUS$]
+		]]>
+	</sql>
+	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMStructureFinder.findByC_G_C_C_N_D">
+		<![CDATA[
+			SELECT
+				{DDMStructure.*}
+			FROM
+				DDMStructure
+			INNER JOIN
+				DDMStructureLink ON
+					(DDMStructure.structureId = DDMStructureLink.structureId)
+			WHERE
+				(DDMStructure.companyId = ?) AND
+				[$GROUP_ID$]
+				(DDMStructureLink.classNameId = ?) AND
+				(DDMStructureLink.classPK = ?) AND
+				(
+					(lower(CAST_TEXT(DDMStructure.name)) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(DDMStructure.description LIKE ? [$AND_OR_NULL_CHECK$])
+				)
+			ORDER BY
+				DDMStructure.structureId DESC
 		]]>
 	</sql>
 	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMStructureFinder.findByC_G_C_N_D_S_T_S">


### PR DESCRIPTION
Hey guys,

I've copied some methods from DDMStructureLinkLocalService to DDMStructureLocalService, because we would want to have a unique service to get structures instead of having two services to get structures depending on the parameters. You can see an example:

```
        @Override
	public List<DDMStructure> getDDMStructures(
			long[] groupIds, long folderId, int restrictionType)
		throws PortalException {

		if (restrictionType ==
				JournalFolderConstants.
					RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW) {

			return **ddmStructureLinkLocalService.getStructureLinkStructures**(
				classNameLocalService.getClassNameId(JournalFolder.class),
				folderId);
		}

		folderId = getOverridedDDMStructuresFolderId(folderId);

		if (folderId != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
			return **ddmStructureLinkLocalService.getStructureLinkStructures**(
				classNameLocalService.getClassNameId(JournalFolder.class),
				folderId);
		}

		long classNameId = classNameLocalService.getClassNameId(
			JournalArticle.class);

		return **ddmStructureLocalService.getStructures**(groupIds, classNameId);
	}
```

Also, when we are trying to get structures using the new methods of "ddmStructureLinkLocalService" we need to pass an order by comparator of DDMStructureLink but we are returning a list of DDMStructures, for us it is a bit strange.

We've only added the methods that we needed, but imho could be a nice idea to add more methods to DDMStructureLocalService from DDMStructureLinkLocalService and replace the occurrences to only use DDMStructureLocalService, because the users of your API don't need to know how it is implemented to get the DDMStructures when they have restrictions.

Let me know if you have any question.

Thanks!!!
Eudaldo.