### PR TITLE
LPS-71385

### DIFF
--- a/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -24,6 +24,12 @@ ResourceBundle resourceBundle = (ResourceBundle)request.getAttribute("liferay-dd
 long ddmTemplateGroupId = PortletDisplayTemplateUtil.getDDMTemplateGroupId(themeDisplay.getScopeGroupId());
 
 Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
+
+if (ddmTemplateGroup.isLayoutPrototype()) {
+	ddmTemplateGroup = GroupLocalServiceUtil.getCompanyGroup(ddmTemplateGroup.getCompanyId());
+
+	ddmTemplateGroupId = ddmTemplateGroup.getGroupId();
+}
 %>
 
 <aui:input id="displayStyleGroupId" name="preferences--displayStyleGroupId--" type="hidden" value="<%= String.valueOf(displayStyleGroupId) %>" />


### PR DESCRIPTION
/cc @jonathanmccann @SamZiemer @moltam89

https://issues.liferay.com/browse/LPS-71385

Please also see: https://github.com/ealonso/liferay-portal/pull/848 (changes split from https://github.com/ealonso/liferay-portal/pull/845)

If an Application Display Template is added using a Page Template, then if a page based on it is exported and imported to a separate environment (the Page Template must be imported as well), then the Application Display Template can no longer be used for portlets on the imported page; there are also various inconsistencies with when these can be selected for the portlets, also related to this issue (should be resolved by these changes).

When a Page Template is created and ADT's are added through portlets on the page, they are added to the scope group of that Page Template; however, this appears to be unintentional, as ADT's cannot be added to Page Templates normally, and this case is not handled when exporting/importing the same way as for Site Templates (for Site Templates, any site based on it will have its data copied, including ADT's, avoiding any confusion by replicating the data with the new site).

After some discussion, although the pattern is not clearly defined, we concluded using the Global site for ADT's from Page Templates makes the most sense, as it is not only a fairly simple solution, but seems that it could be the only way to handle this case in a way applicable to 6.2 as well (in 6.2, this kind of dependency between sites would only work between environments for the Global site). Given that they work differently from Site Templates, and you cannot normally create ADT's for a Page Template, it still seems consistent with the pattern in place, too.