### PR TITLE
LPS-73368 Leave schema version 1.0.* free for backporteable upgrades. In this way DXP users will be aligned with schemaVersion in future releases

### DIFF
--- a/dynamic-data-mapping-service/bnd.bnd
+++ b/dynamic-data-mapping-service/bnd.bnd
@@ -14,5 +14,5 @@ Export-Package:\
 	com.liferay.dynamic.data.mapping.webdav
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Dynamic Data Mapping
-Liferay-Require-SchemaVersion: 1.0.4
+Liferay-Require-SchemaVersion: 1.1.1
 Liferay-Service: true

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
@@ -86,6 +86,10 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"com.liferay.dynamic.data.mapping.service", "1.0.1", "1.0.2",
+			new UpgradeDDMTemplateSmallImageURL());
+
+		registry.register(
+			"com.liferay.dynamic.data.mapping.service", "1.0.2", "1.1.0",
 			new UpgradeCheckboxFieldToCheckboxMultipleField(
 				_ddmFormJSONDeserializer, _ddmFormValuesJSONDeserializer,
 				_ddmFormValuesJSONSerializer, _jsonFactory),
@@ -97,17 +101,13 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 				UpgradeDataProviderInstance(_jsonFactory));
 
 		registry.register(
-			"com.liferay.dynamic.data.mapping.service", "1.0.2", "1.0.3",
+			"com.liferay.dynamic.data.mapping.service", "1.1.0", "1.1.1",
 			new UpgradeDDMFormFieldSettings(
 				_ddmFormJSONDeserializer, _ddmFormJSONSerializer),
 			new com.liferay.dynamic.data.mapping.internal.upgrade.v1_0_3.
 				UpgradeDataProviderInstance(
 					_ddmFormValuesJSONDeserializer,
 					_ddmFormValuesJSONSerializer));
-
-		registry.register(
-			"com.liferay.dynamic.data.mapping.service", "1.0.3", "1.0.4",
-			new UpgradeDDMTemplateSmallImageURL());
 	}
 
 	@Reference


### PR DESCRIPTION
Hi @rafaprax,@leoadb,

I have moved these 2 upgrade processes because they are not backporteable however we need to backport _UpgradeDDMTemplateSmallImageURL_. If we don't keep 1.0.* for those upgrade which can be backporteable, DXP users won't be able to upgrade to future releases in the future. Please, take into account this for other modules too.

Please, let me know if you have any question regarding this.

Thanks.

cc/ @marcellustavares 

