### PR TITLE
LPS-73376 Remove sortable list's repeatable-element placeholder node

### DIFF
--- a/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -43,8 +43,6 @@ AUI.add(
 
 		var TPL_REPEATABLE_HELPER = '<div class="lfr-ddm-repeatable-helper"></div>';
 
-		var TPL_REPEATABLE_PLACEHOLDER = '<div class="lfr-ddm-repeatable-placeholder"></div>';
-
 		var TPL_REQUIRED_MARK = '<span class="icon-asterisk text-warning"><span class="hide-accessible">' + Liferay.Language.get('required') + '</span></span>';
 
 		var FieldTypes = Liferay.namespace('DDM.FieldTypes');
@@ -2945,7 +2943,6 @@ AUI.add(
 									dropOn: field.get('container').get('parentNode'),
 									helper: A.Node.create(TPL_REPEATABLE_HELPER),
 									nodes: '[data-fieldName=' + fieldName + ']',
-									placeholder: A.Node.create(TPL_REPEATABLE_PLACEHOLDER),
 									sortCondition: function(event) {
 										var dropNode = event.drop.get('node');
 


### PR DESCRIPTION
/cc @JonathanAichler

Notes from Jonathan:

> The presence of the placeholder here was causing an issue with reordering repeatable elements in web content structures. It would hide the repeatable node that was being moved and would show the blank placeholder. Removing the placeholder initialization here allows for code to default to using the repeatable node itself.
> 
> LPP
> https://issues.liferay.com/browse/LPP-25759
> 
> LPS
> https://issues.liferay.com/browse/LPS-73376