### PR TITLE
LPS-50640 Map type hibernate fields are serialized and deserialized b…

### DIFF
--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/background/task/DDMStructureIndexerBackgroundTaskExecutor.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/background/task/DDMStructureIndexerBackgroundTaskExecutor.java
@@ -65,7 +65,8 @@ public class DDMStructureIndexerBackgroundTaskExecutor
 		Map<String, Serializable> taskContextMap =
 			backgroundTask.getTaskContextMap();
 
-		long structureId = (long)taskContextMap.get("structureId");
+		long structureId =
+			((Number)taskContextMap.get("structureId")).longValue();
 
 		DDMStructureIndexer structureIndexer = getDDMStructureIndexer(
 			structureId);


### PR DESCRIPTION
…y com.liferay.portal.dao.orm.hibernate.MapType, which is using Json serializer. One of the fatal issue in this solution is, for number types, the type info is eased during serialization. So during deserialization, the json lib is simply base on the number value range to choose a type for it. In this case, we serialize a small Long, then deserialized back an Integer. And DDMStructureIndexerBackgroundTaskExecutor is doing the blinded casting, which would fail with "java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long". Caused by ff216211637c8c3f82e652fb35357096f02ae14c . A more complex deeper fix should be done inside the json lib, to properly carry on number types, so that we can deserialize them back as correct types. But for now, let's just fix this single broken usage.

CC @danielkocsis 