### PR TITLE
LPS-74283 Since we always add a DDMStructureLayout we need to make sure that the UUID is unique. In case of journal import the service context might have a wrong uuid value

### DIFF
--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -1630,6 +1630,11 @@ public class DDMStructureLocalServiceImpl
 
 		// Structure layout
 
+		// Explicitly pop uuid from service context to ensure no lingering
+		// values remain there from other components eg.: Journal
+
+		serviceContext.getUuid();
+
 		ddmStructureLayoutLocalService.addStructureLayout(
 			structureVersion.getUserId(), structureVersion.getGroupId(),
 			structureVersion.getStructureVersionId(), ddmFormLayout,


### PR DESCRIPTION
when importing a journal article - a default structure value - the service context is filled with the article's uuid.

although when it's an update the uuid never gets popped for journal and it's accidentally being used in ddm, ending up in constraint violation exceptions as the journal is imported the second time.