### PR TITLE
LPS-75963 Don't add second Required mark to a DDM Form Field for IE

### DIFF
--- a/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -561,7 +561,7 @@ AUI.add(
 
 							var fieldDefinition = instance.getFieldDefinition();
 
-							if (fieldDefinition.required) {
+							if (!A.UA.ie && fieldDefinition.required) {
 								labelNode.append(TPL_REQUIRED_MARK);
 							}
 


### PR DESCRIPTION
/cc @gregory-bretall 