### PR TITLE
[Technical Support] LPS-76292 Guard against the case the original author of the structure has been deleted

### DIFF
--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -1530,8 +1530,8 @@ public class DDMStructureLocalServiceImpl
 
 		structureVersion.setGroupId(structure.getGroupId());
 		structureVersion.setCompanyId(structure.getCompanyId());
-		structureVersion.setUserId(structure.getUserId());
-		structureVersion.setUserName(structure.getUserName());
+		structureVersion.setUserId(user.getUserId());
+		structureVersion.setUserName(user.getFullName());
 		structureVersion.setCreateDate(structure.getModifiedDate());
 		structureVersion.setStructureId(structure.getStructureId());
 		structureVersion.setVersion(version);


### PR DESCRIPTION
Is it okay?

See https://issues.liferay.com/browse/LPS-76292

In a related not, it's not compiling on my machine due to the following reason unrelated to my fix:

```
/Users/thecleydyr/liferay/source/com-liferay-dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java:697: error: unreported exception PortalException; must be caught or declared to be thrown
                                PortalUtil.getAncestorSiteGroupIds(groupId)) {
                                                                  ^
```

I just ignored it in hopes that it is something idiosyncratic to my machine.

Thanks