### PR TITLE
[Technical Support] LPS-76501 - Auto SF.

### DIFF
--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
@@ -50,7 +50,6 @@ import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -1627,6 +1626,17 @@ public class DDMTemplateLocalServiceImpl
 	}
 
 	protected void validate(
+			long groupId, Map<Locale, String> nameMap, String script)
+		throws PortalException {
+
+		validateName(groupId, nameMap);
+
+		if (Validator.isNull(script)) {
+			throw new TemplateScriptException("Script is null");
+		}
+	}
+
+	protected void validate(
 			long groupId, Map<Locale, String> nameMap, String script,
 			boolean smallImage, String smallImageURL, File smallImageFile,
 			byte[] smallImageBytes)
@@ -1675,17 +1685,6 @@ public class DDMTemplateLocalServiceImpl
 					String.valueOf(smallImageBytes.length),
 					" bytes and exceeds the maximum size of ",
 					String.valueOf(smallImageMaxSize)));
-		}
-	}
-
-	protected void validate(
-			long groupId, Map<Locale, String> nameMap, String script)
-		throws PortalException {
-
-		validateName(groupId, nameMap);
-
-		if (Validator.isNull(script)) {
-			throw new TemplateScriptException("Script is null");
 		}
 	}
 

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
@@ -1632,7 +1632,7 @@ public class DDMTemplateLocalServiceImpl
 			byte[] smallImageBytes)
 		throws PortalException {
 
-		validate(nameMap, script);
+		validate(groupId, nameMap, script);
 
 		if (!smallImage || Validator.isNotNull(smallImageURL) ||
 			(smallImageFile == null) || (smallImageBytes == null)) {
@@ -1678,20 +1678,21 @@ public class DDMTemplateLocalServiceImpl
 		}
 	}
 
-	protected void validate(Map<Locale, String> nameMap, String script)
+	protected void validate(
+			long groupId, Map<Locale, String> nameMap, String script)
 		throws PortalException {
 
-		validateName(nameMap);
+		validateName(groupId, nameMap);
 
 		if (Validator.isNull(script)) {
 			throw new TemplateScriptException("Script is null");
 		}
 	}
 
-	protected void validateName(Map<Locale, String> nameMap)
+	protected void validateName(long groupId, Map<Locale, String> nameMap)
 		throws PortalException {
 
-		String name = nameMap.get(LocaleUtil.getSiteDefault());
+		String name = nameMap.get(PortalUtil.getSiteDefaultLocale(groupId));
 
 		if (Validator.isNull(name)) {
 			throw new TemplateNameException("Name is null");


### PR DESCRIPTION
Hey guys,

I've just reviewed this fix and it looks good to me. This fix replaces the method used to get the default locale during the DDM validation, i.e. replaces **LocaleUtil.getSiteDefault()** by **PortalUtil.getSiteDefaultLocale(groupId)**. It was necessary because, according to @achaparro, the **LocaleThreadLocal**, used by **LocaleUtil.getSiteDefault()**, isn't initialized during the Upgrade Process and it causes the issue described in [LPS-76501](https://issues.liferay.com/browse/LPS-76501).

@IstvanD and @achaparro, if there is anything incorrect or you want to add some other information, please feel free to do it.

Thanks.

**Note**: The CI result of the first pull request is available [here](https://github.com/natocesarrego/com-liferay-dynamic-data-mapping/pull/4#issuecomment-355573834). I've already fixed a source format issue through 06bcaee.