### PR TITLE
LPS-77167 DDMStructureLocalServiceImpl userId fix

### DIFF
--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -1605,6 +1605,7 @@ public class DDMStructureLocalServiceImpl
 		validate(nameMap, parentDDMForm, ddmForm);
 
 		structure.setParentStructureId(parentStructureId);
+		structure.setUserId(userId);
 
 		DDMStructureVersion latestStructureVersion =
 			ddmStructureVersionLocalService.getLatestStructureVersion(


### PR DESCRIPTION
during staging import phase the correct user id is being passed to the local service based on the publication user id strategy.
this local services was ignoring the user id at some point causing a problem when importing an entity and in some cases the user id did not referenced a valid user on the import system